### PR TITLE
Use random resource name

### DIFF
--- a/internal/provider/resource_mackerel_dashboard_test.go
+++ b/internal/provider/resource_mackerel_dashboard_test.go
@@ -24,7 +24,7 @@ func TestAccMackerelDashboard_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "title", rName),
 					resource.TestCheckResourceAttr(
-						"mackerel_dashboard.foobar", "url_path", fmt.Sprintf("%s/bar/baz", rName)),
+						"mackerel_dashboard.foobar", "url_path", fmt.Sprintf("%s/foo/bar", rName)),
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "body_markdown", "# Head1\n## Head2\n\n* List1\n* List2\n"),
 				),
@@ -47,7 +47,7 @@ func TestAccMackerelDashboard_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "title", rName),
 					resource.TestCheckResourceAttr(
-						"mackerel_dashboard.foobar", "url_path", fmt.Sprintf("%s/bar/baz", rName)),
+						"mackerel_dashboard.foobar", "url_path", fmt.Sprintf("%s/foo/bar", rName)),
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "body_markdown", "# Head1\n## Head2\n\n* List1\n* List2\n"),
 				),

--- a/internal/provider/resource_mackerel_dashboard_test.go
+++ b/internal/provider/resource_mackerel_dashboard_test.go
@@ -4,22 +4,25 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestAccMackerelDashboard_Basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestDashboard-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelDashboardDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelDashboardConfig_basic,
+				Config: testAccCheckMackerelDashboardConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_dashboard.foobar", "title", "terraform_for_mackerel_test_foobar"),
+						"mackerel_dashboard.foobar", "title", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "url_path", "foo/bar"),
 					resource.TestCheckResourceAttr(
@@ -31,16 +34,18 @@ func TestAccMackerelDashboard_Basic(t *testing.T) {
 }
 
 func TestAccMackerelDashboard_Update(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestDashboard-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelDashboardDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelDashboardConfig_basic,
+				Config: testAccCheckMackerelDashboardConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_dashboard.foobar", "title", "terraform_for_mackerel_test_foobar"),
+						"mackerel_dashboard.foobar", "title", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "url_path", "foo/bar"),
 					resource.TestCheckResourceAttr(
@@ -48,10 +53,10 @@ func TestAccMackerelDashboard_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckMackerelDashboardConfig_update,
+				Config: testAccCheckMackerelDashboardConfigUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_dashboard.foobar", "title", "terraform_for_mackerel_test_foobar_upd"),
+						"mackerel_dashboard.foobar", "title", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "url_path", "bar/baz"),
 					resource.TestCheckResourceAttr(
@@ -79,9 +84,10 @@ func testAccCheckMackerelDashboardDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccCheckMackerelDashboardConfig_basic = `
+func testAccCheckMackerelDashboardConfigBasic(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_dashboard" "foobar" {
-  title         = "terraform_for_mackerel_test_foobar"
+  title         = "%s"
   url_path      = "foo/bar"
 	body_markdown = <<EOF
 # Head1
@@ -90,11 +96,13 @@ resource "mackerel_dashboard" "foobar" {
 * List1
 * List2
 EOF
-}`
+}`, rName)
+}
 
-const testAccCheckMackerelDashboardConfig_update = `
+func testAccCheckMackerelDashboardConfigUpdate(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_dashboard" "foobar" {
-  title         = "terraform_for_mackerel_test_foobar_upd"
+  title         = "%s"
   url_path      = "bar/baz"
 	body_markdown = <<EOF
 # Head1
@@ -102,4 +110,5 @@ resource "mackerel_dashboard" "foobar" {
 
 [Link](https://terraform.io/)
 EOF
-}`
+}`, rName)
+}

--- a/internal/provider/resource_mackerel_dashboard_test.go
+++ b/internal/provider/resource_mackerel_dashboard_test.go
@@ -24,7 +24,7 @@ func TestAccMackerelDashboard_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "title", rName),
 					resource.TestCheckResourceAttr(
-						"mackerel_dashboard.foobar", "url_path", "foo/bar"),
+						"mackerel_dashboard.foobar", "url_path", fmt.Sprintf("%s/bar/baz", rName)),
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "body_markdown", "# Head1\n## Head2\n\n* List1\n* List2\n"),
 				),
@@ -47,7 +47,7 @@ func TestAccMackerelDashboard_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "title", rName),
 					resource.TestCheckResourceAttr(
-						"mackerel_dashboard.foobar", "url_path", "foo/bar"),
+						"mackerel_dashboard.foobar", "url_path", fmt.Sprintf("%s/bar/baz", rName)),
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "body_markdown", "# Head1\n## Head2\n\n* List1\n* List2\n"),
 				),
@@ -58,7 +58,7 @@ func TestAccMackerelDashboard_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "title", rName),
 					resource.TestCheckResourceAttr(
-						"mackerel_dashboard.foobar", "url_path", "bar/baz"),
+						"mackerel_dashboard.foobar", "url_path", fmt.Sprintf("%s/bar/baz", rName)),
 					resource.TestCheckResourceAttr(
 						"mackerel_dashboard.foobar", "body_markdown", "# Head1\n## Head2\n\n[Link](https://terraform.io/)\n"),
 				),
@@ -88,7 +88,7 @@ func testAccCheckMackerelDashboardConfigBasic(rName string) string {
 	return fmt.Sprintf(`
 resource "mackerel_dashboard" "foobar" {
   title         = "%s"
-  url_path      = "foo/bar"
+  url_path      = "%s/foo/bar"
 	body_markdown = <<EOF
 # Head1
 ## Head2
@@ -96,19 +96,19 @@ resource "mackerel_dashboard" "foobar" {
 * List1
 * List2
 EOF
-}`, rName)
+}`, rName, rName)
 }
 
 func testAccCheckMackerelDashboardConfigUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "mackerel_dashboard" "foobar" {
   title         = "%s"
-  url_path      = "bar/baz"
+  url_path      = "%s/bar/baz"
 	body_markdown = <<EOF
 # Head1
 ## Head2
 
 [Link](https://terraform.io/)
 EOF
-}`, rName)
+}`, rName, rName)
 }

--- a/internal/provider/resource_mackerel_expression_monitor_test.go
+++ b/internal/provider/resource_mackerel_expression_monitor_test.go
@@ -4,22 +4,25 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestAccMackerelExpressionMonitor_Basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestExpressionMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelExpressionMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelExpressionMonitorConfig_basic,
+				Config: testAccCheckMackerelExpressionMonitorConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_expression_monitor.foobar", "name", "terraform_for_mackerel_test_foobar"),
+						"mackerel_expression_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_expression_monitor.foobar", "expression", `avg(roleSlots("server:role","loadavg5"))`),
 					resource.TestCheckResourceAttr(
@@ -37,16 +40,18 @@ func TestAccMackerelExpressionMonitor_Basic(t *testing.T) {
 }
 
 func TestAccMackerelExpressionMonitor_Update(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestExpressionMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelExpressionMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelExpressionMonitorConfig_basic,
+				Config: testAccCheckMackerelExpressionMonitorConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_expression_monitor.foobar", "name", "terraform_for_mackerel_test_foobar"),
+						"mackerel_expression_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_expression_monitor.foobar", "expression", `avg(roleSlots("server:role","loadavg5"))`),
 					resource.TestCheckResourceAttr(
@@ -60,10 +65,10 @@ func TestAccMackerelExpressionMonitor_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckMackerelExpressionMonitorConfig_update,
+				Config: testAccCheckMackerelExpressionMonitorConfigUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_expression_monitor.foobar", "name", "terraform_for_mackerel_test_foobar_upd"),
+						"mackerel_expression_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_expression_monitor.foobar", "expression", `avg(roleSlots("server:role","loadavg5"))`),
 					resource.TestCheckResourceAttr(
@@ -81,16 +86,18 @@ func TestAccMackerelExpressionMonitor_Update(t *testing.T) {
 }
 
 func TestAccMackerelExpressionMonitor_Minimum(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestExpressionMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelExpressionMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelExpressionMonitorConfig_minimum,
+				Config: testAccCheckMackerelExpressionMonitorConfigMinimum(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_expression_monitor.foobar", "name", "terraform_for_mackerel_test_foobar"),
+						"mackerel_expression_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_expression_monitor.foobar", "expression", `avg(roleSlots("server:role","loadavg5"))`),
 					resource.TestCheckResourceAttr(
@@ -129,32 +136,38 @@ func testAccCheckMackerelExpressionMonitorDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccCheckMackerelExpressionMonitorConfig_basic = `
+func testAccCheckMackerelExpressionMonitorConfigBasic(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_expression_monitor" "foobar" {
-    name                  = "terraform_for_mackerel_test_foobar"
+    name                  = "%s"
     expression            = "avg(roleSlots(\"server:role\",\"loadavg5\"))"
     operator              = ">"
     warning               = 80.0
     critical              = 90.0
     notification_interval = 10
-}`
+}`, rName)
+}
 
-const testAccCheckMackerelExpressionMonitorConfig_update = `
+func testAccCheckMackerelExpressionMonitorConfigUpdate(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_expression_monitor" "foobar" {
-    name                  = "terraform_for_mackerel_test_foobar_upd"
+    name                  = "%s"
     expression            = "avg(roleSlots(\"server:role\",\"loadavg5\"))"
     operator              = ">"
     warning               = 85.5
     critical              = 95.5
     notification_interval = 10
-}`
+}`, rName)
+}
 
-const testAccCheckMackerelExpressionMonitorConfig_minimum = `
+func testAccCheckMackerelExpressionMonitorConfigMinimum(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_expression_monitor" "foobar" {
-    name                  = "terraform_for_mackerel_test_foobar"
+    name                  = "%s"
     expression            = "avg(roleSlots(\"server:role\",\"loadavg5\"))"
     operator              = ">"
     warning               = 80.0
     critical              = 90.0
     notification_interval = 10
-}`
+}`, rName)
+}

--- a/internal/provider/resource_mackerel_external_monitor_test.go
+++ b/internal/provider/resource_mackerel_external_monitor_test.go
@@ -4,26 +4,29 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestAccMackerelExternalMonitor_Basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestExternalMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelExternalMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelExternalMonitorConfig_basic,
+				Config: testAccCheckMackerelExternalMonitorConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_external_monitor.foobar", "name", "terraform_for_mackerel_test_foobar"),
+						"mackerel_external_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_external_monitor.foobar", "url", "https://terraform.io/"),
 					resource.TestCheckResourceAttr(
-						"mackerel_external_monitor.foobar", "service", "Web"),
+						"mackerel_external_monitor.foobar", "service", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_external_monitor.foobar", "notification_interval", "10"),
 					resource.TestCheckResourceAttr(
@@ -57,20 +60,22 @@ func TestAccMackerelExternalMonitor_Basic(t *testing.T) {
 }
 
 func TestAccMackerelExternalMonitor_Update(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestExternalMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelExternalMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelExternalMonitorConfig_basic,
+				Config: testAccCheckMackerelExternalMonitorConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_external_monitor.foobar", "name", "terraform_for_mackerel_test_foobar"),
+						"mackerel_external_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_external_monitor.foobar", "url", "https://terraform.io/"),
 					resource.TestCheckResourceAttr(
-						"mackerel_external_monitor.foobar", "service", "Web"),
+						"mackerel_external_monitor.foobar", "service", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_external_monitor.foobar", "notification_interval", "10"),
 					resource.TestCheckResourceAttr(
@@ -94,14 +99,14 @@ func TestAccMackerelExternalMonitor_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckMackerelExternalMonitorConfig_update,
+				Config: testAccCheckMackerelExternalMonitorConfigUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_external_monitor.foobar", "name", "terraform_for_mackerel_test_foobar_upd"),
+						"mackerel_external_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_external_monitor.foobar", "url", "https://terraform.io/"),
 					resource.TestCheckResourceAttr(
-						"mackerel_external_monitor.foobar", "service", "Web"),
+						"mackerel_external_monitor.foobar", "service", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_external_monitor.foobar", "notification_interval", "10"),
 					resource.TestCheckResourceAttr(
@@ -131,16 +136,18 @@ func TestAccMackerelExternalMonitor_Update(t *testing.T) {
 }
 
 func TestAccMackerelExternalMonitor_Minimum(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestExternalMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelExternalMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelExternalMonitorConfig_minimum,
+				Config: testAccCheckMackerelExternalMonitorConfigMinimum(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_external_monitor.foobar", "name", "terraform_for_mackerel_test_foobar_min"),
+						"mackerel_external_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_external_monitor.foobar", "url", "https://terraform.io/"),
 				),
@@ -171,13 +178,14 @@ func testAccCheckMackerelExternalMonitorDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccCheckMackerelExternalMonitorConfig_basic = `
+func testAccCheckMackerelExternalMonitorConfigBasic(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_service" "web" {
-  name = "Web"
+  name = "%s"
 }
 
 resource "mackerel_external_monitor" "foobar" {
-  name                   = "terraform_for_mackerel_test_foobar"
+  name                   = "%s"
   url                    = "https://terraform.io/"
   service                = mackerel_service.web.name
   notification_interval  = 10
@@ -199,15 +207,17 @@ resource "mackerel_external_monitor" "foobar" {
   }
 
   memo = "XXX"
-}`
+}`, rName, rName)
+}
 
-const testAccCheckMackerelExternalMonitorConfig_update = `
+func testAccCheckMackerelExternalMonitorConfigUpdate(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_service" "web" {
-  name = "Web"
+  name = "%s"
 }
 
 resource "mackerel_external_monitor" "foobar" {
-  name                   = "terraform_for_mackerel_test_foobar_upd"
+  name                   = "%s"
   url                    = "https://terraform.io/"
   method                 = "POST"
   service                = mackerel_service.web.name
@@ -222,10 +232,13 @@ resource "mackerel_external_monitor" "foobar" {
   certification_expiration_critical = 30
 
   skip_certificate_verification = true
-}`
+}`, rName, rName)
+}
 
-const testAccCheckMackerelExternalMonitorConfig_minimum = `
+func testAccCheckMackerelExternalMonitorConfigMinimum(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_external_monitor" "foobar" {
-  name                   = "terraform_for_mackerel_test_foobar_min"
+  name                   = "%s"
   url                    = "https://terraform.io/"
-}`
+}`, rName)
+}

--- a/internal/provider/resource_mackerel_host_monitor_test.go
+++ b/internal/provider/resource_mackerel_host_monitor_test.go
@@ -4,22 +4,25 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestAccMackerelHostMonitor_Basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestHostMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelHostMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelHostMonitorConfig_basic,
+				Config: testAccCheckMackerelHostMonitorConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_host_monitor.foobar", "name", "terraform_for_mackerel_test_foobar"),
+						"mackerel_host_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "duration", "10"),
 					resource.TestCheckResourceAttr(
@@ -43,16 +46,18 @@ func TestAccMackerelHostMonitor_Basic(t *testing.T) {
 }
 
 func TestAccMackerelHostMonitor_Update(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestHostMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelHostMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelHostMonitorConfig_basic,
+				Config: testAccCheckMackerelHostMonitorConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_host_monitor.foobar", "name", "terraform_for_mackerel_test_foobar"),
+						"mackerel_host_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "duration", "10"),
 					resource.TestCheckResourceAttr(
@@ -72,10 +77,10 @@ func TestAccMackerelHostMonitor_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckMackerelHostMonitorConfig_update,
+				Config: testAccCheckMackerelHostMonitorConfigUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_host_monitor.foobar", "name", "terraform_for_mackerel_test_foobar_upd"),
+						"mackerel_host_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "duration", "10"),
 					resource.TestCheckResourceAttr(
@@ -99,16 +104,18 @@ func TestAccMackerelHostMonitor_Update(t *testing.T) {
 }
 
 func TestAccMackerelHostMonitor_Minimum(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestHostMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelHostMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelHostMonitorConfig_minimum,
+				Config: testAccCheckMackerelHostMonitorConfigMinimum(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_host_monitor.foobar", "name", "terraform_for_mackerel_test_foobar"),
+						"mackerel_host_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "duration", "10"),
 					resource.TestCheckResourceAttr(
@@ -149,35 +156,41 @@ func testAccCheckMackerelHostMonitorDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccCheckMackerelHostMonitorConfig_basic = `
+func testAccCheckMackerelHostMonitorConfigBasic(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_host_monitor" "foobar" {
-    name                  = "terraform_for_mackerel_test_foobar"
+    name                  = "%s"
     duration              = 10
-    metric                = "cpu%"
+    metric                = "cpu%%"
     operator              = ">"
     warning               = 80.0
     critical              = 90.0
     notification_interval = 10
-}`
+}`, rName)
+}
 
-const testAccCheckMackerelHostMonitorConfig_update = `
+func testAccCheckMackerelHostMonitorConfigUpdate(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_host_monitor" "foobar" {
-    name                  = "terraform_for_mackerel_test_foobar_upd"
+    name                  = "%s"
     duration              = 10
-    metric                = "cpu%"
+    metric                = "cpu%%"
     operator              = ">"
     warning               = 85.5
     critical              = 95.5
     notification_interval = 10
-}`
+}`, rName)
+}
 
-const testAccCheckMackerelHostMonitorConfig_minimum = `
+func testAccCheckMackerelHostMonitorConfigMinimum(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_host_monitor" "foobar" {
-    name                  = "terraform_for_mackerel_test_foobar"
+    name                  = "%s"
     duration              = 10
-    metric                = "cpu%"
+    metric                = "cpu%%"
     operator              = ">"
     warning               = 80.0
     critical              = 90.0
     notification_interval = 10
-}`
+}`, rName)
+}

--- a/internal/provider/resource_mackerel_service_monitor_test.go
+++ b/internal/provider/resource_mackerel_service_monitor_test.go
@@ -4,24 +4,27 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestAccMackerelServiceMonitor_Basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestServiceMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelServiceMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelServiceMonitorConfig_basic,
+				Config: testAccMackerelServiceMonitorConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_service_monitor.foobar", "name", "terraform_for_mackerel_test_foobar"),
+						"mackerel_service_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
-						"mackerel_service_monitor.foobar", "service", "Blog"),
+						"mackerel_service_monitor.foobar", "service", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "duration", "10"),
 					resource.TestCheckResourceAttr(
@@ -41,18 +44,20 @@ func TestAccMackerelServiceMonitor_Basic(t *testing.T) {
 }
 
 func TestAccMackerelServiceMonitor_Update(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestServiceMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelServiceMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelServiceMonitorConfig_basic,
+				Config: testAccMackerelServiceMonitorConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_service_monitor.foobar", "name", "terraform_for_mackerel_test_foobar"),
+						"mackerel_service_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
-						"mackerel_service_monitor.foobar", "service", "Blog"),
+						"mackerel_service_monitor.foobar", "service", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "duration", "10"),
 					resource.TestCheckResourceAttr(
@@ -68,12 +73,12 @@ func TestAccMackerelServiceMonitor_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckMackerelServiceMonitorConfig_update,
+				Config: testAccMackerelServiceMonitorConfigUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_service_monitor.foobar", "name", "terraform_for_mackerel_test_foobar_upd"),
+						"mackerel_service_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
-						"mackerel_service_monitor.foobar", "service", "Blog"),
+						"mackerel_service_monitor.foobar", "service", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "duration", "10"),
 					resource.TestCheckResourceAttr(
@@ -93,18 +98,20 @@ func TestAccMackerelServiceMonitor_Update(t *testing.T) {
 }
 
 func TestAccMackerelServiceMonitor_Minimum(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestServiceMonitor-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelServiceMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelServiceMonitorConfig_minimum,
+				Config: testAccMackerelServiceMonitorConfigMinimum(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_service_monitor.foobar", "name", "terraform_for_mackerel_test_foobar"),
+						"mackerel_service_monitor.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
-						"mackerel_service_monitor.foobar", "service", "Blog"),
+						"mackerel_service_monitor.foobar", "service", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "duration", "10"),
 					resource.TestCheckResourceAttr(
@@ -145,50 +152,59 @@ func testAccCheckMackerelServiceMonitorDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccCheckMackerelServiceMonitorConfig_basic = `
-resource "mackerel_service" "blog" {
-  name = "Blog"
+func testAccMackerelServiceMonitorConfigBasic(rName string) string {
+	return fmt.Sprintf(`
+resource "mackerel_service" "foobar" {
+    name = "%s"
 }
 
 resource "mackerel_service_monitor" "foobar" {
-  name                  = "terraform_for_mackerel_test_foobar"
-  service               = mackerel_service.blog.name
+  name                  = "%s"
+  service               = mackerel_service.foobar.name
   duration              = 10
-  metric                = "cpu%"
+  metric                = "cpu%%"
   operator              = ">"
   warning               = 80.0
   critical              = 90.0
   notification_interval = 10
-}`
+}
+`, rName, rName)
+}
 
-const testAccCheckMackerelServiceMonitorConfig_update = `
-resource "mackerel_service" "blog" {
-  name = "Blog"
+func testAccMackerelServiceMonitorConfigUpdate(rName string) string {
+	return fmt.Sprintf(`
+resource "mackerel_service" "foobar" {
+    name = "%s"
 }
 
 resource "mackerel_service_monitor" "foobar" {
-  name                  = "terraform_for_mackerel_test_foobar_upd"
-  service               = mackerel_service.blog.name
+  name                  = "%s"
+  service               = mackerel_service.foobar.name
   duration              = 10
-  metric                = "cpu%"
+  metric                = "cpu%%"
   operator              = ">"
   warning               = 85.5
   critical              = 95.5
   notification_interval = 10
-}`
+}
+`, rName, rName)
+}
 
-const testAccCheckMackerelServiceMonitorConfig_minimum = `
-resource "mackerel_service" "blog" {
-  name = "Blog"
+func testAccMackerelServiceMonitorConfigMinimum(rName string) string {
+	return fmt.Sprintf(`
+resource "mackerel_service" "foobar" {
+    name = "%s"
 }
 
 resource "mackerel_service_monitor" "foobar" {
-  name                  = "terraform_for_mackerel_test_foobar"
-  service               = mackerel_service.blog.name
+  name                  = "%s"
+  service               = mackerel_service.foobar.name
   duration              = 10
-  metric                = "cpu%"
+  metric                = "cpu%%"
   operator              = ">"
   warning               = 80.0
   critical              = 90.0
   notification_interval = 10
-}`
+}
+`, rName, rName)
+}

--- a/internal/provider/resource_mackerel_service_test.go
+++ b/internal/provider/resource_mackerel_service_test.go
@@ -4,22 +4,25 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestAccMackerelService_Basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestService-")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMackerelServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMackerelServiceConfig_basic,
+				Config: testAccMackerelServiceConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"mackerel_service.foobar", "name", "foobar"),
+						"mackerel_service.foobar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"mackerel_service.foobar", "memo", "xxxxx"),
 				),
@@ -50,8 +53,11 @@ func testAccCheckMackerelServiceDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccCheckMackerelServiceConfig_basic = `
+func testAccMackerelServiceConfigBasic(rName string) string {
+	return fmt.Sprintf(`
 resource "mackerel_service" "foobar" {
-    name = "foobar"
+    name = "%s"
     memo = "xxxxx"
-}`
+}
+`, rName)
+}


### PR DESCRIPTION
To fix an issue where tests fail when running tests in parallel.