### PR TITLE
Add max_check_attempts to host and service monitor 

### DIFF
--- a/internal/provider/resource_mackerel_external_monitor.go
+++ b/internal/provider/resource_mackerel_external_monitor.go
@@ -54,10 +54,10 @@ func resourceMackerelExternalMonitor() *schema.Resource {
 				Optional: true,
 			},
 			"max_check_attempts": {
-				Type:     schema.TypeFloat,
-				Optional: true,
-				Default:  1,
-				//ValidateFunc: validateDurationTime 1 - 10
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				ValidateFunc: validation.IntBetween(1, 10),
 			},
 			"certification_expiration_warning": {
 				Type:     schema.TypeInt,
@@ -204,7 +204,7 @@ func getMackerelExternalMonitorInput(d *schema.ResourceData) *mackerel.MonitorEx
 		input.ContainsString = v.(string)
 	}
 	if v, ok := d.GetOk("max_check_attempts"); ok {
-		input.MaxCheckAttempts = uint64(v.(float64))
+		input.MaxCheckAttempts = uint64(v.(int))
 	}
 	if v, ok := d.GetOk("certification_expiration_warning"); ok {
 		input.CertificationExpirationWarning = puint64(uint64(v.(int)))

--- a/internal/provider/resource_mackerel_host_monitor.go
+++ b/internal/provider/resource_mackerel_host_monitor.go
@@ -4,6 +4,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/mackerelio/mackerel-client-go"
 )
 
@@ -46,6 +48,12 @@ func resourceMackerelHostMonitor() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"max_check_attempts": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Default:      1,
+			},
 			"scopes": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -76,6 +84,7 @@ func resourceMackerelHostMonitorCreate(d *schema.ResourceData, meta interface{})
 		Warning:              pfloat64(d.Get("warning").(float64)),
 		Critical:             pfloat64(d.Get("critical").(float64)),
 		NotificationInterval: uint64(d.Get("notification_interval").(int)),
+		MaxCheckAttempts:     uint64(d.Get("max_check_attempts").(int)),
 		IsMute:               d.Get("is_mute").(bool),
 	}
 
@@ -118,6 +127,7 @@ func resourceMackerelHostMonitorRead(d *schema.ResourceData, meta interface{}) e
 			_ = d.Set("warning", mon.Warning)
 			_ = d.Set("critical", mon.Critical)
 			_ = d.Set("notification_interval", mon.NotificationInterval)
+			_ = d.Set("max_check_attempts", mon.MaxCheckAttempts)
 			_ = d.Set("scopes", flattenStringList(mon.Scopes))
 			_ = d.Set("exclude_scopes", flattenStringList(mon.ExcludeScopes))
 			_ = d.Set("is_mute", mon.IsMute)
@@ -140,6 +150,7 @@ func resourceMackerelHostMonitorUpdate(d *schema.ResourceData, meta interface{})
 		Warning:              pfloat64(d.Get("warning").(float64)),
 		Critical:             pfloat64(d.Get("critical").(float64)),
 		NotificationInterval: uint64(d.Get("notification_interval").(int)),
+		MaxCheckAttempts:     uint64(d.Get("max_check_attempts").(int)),
 		IsMute:               d.Get("is_mute").(bool),
 	}
 

--- a/internal/provider/resource_mackerel_host_monitor_test.go
+++ b/internal/provider/resource_mackerel_host_monitor_test.go
@@ -36,6 +36,8 @@ func TestAccMackerelHostMonitor_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "notification_interval", "10"),
 					resource.TestCheckResourceAttr(
+						"mackerel_host_monitor.foobar", "max_check_attempts", "3"),
+					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "scopes.#", "0"),
 					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "exclude_scopes.#", "0"),
@@ -71,6 +73,8 @@ func TestAccMackerelHostMonitor_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "notification_interval", "10"),
 					resource.TestCheckResourceAttr(
+						"mackerel_host_monitor.foobar", "max_check_attempts", "3"),
+					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "scopes.#", "0"),
 					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "exclude_scopes.#", "0"),
@@ -93,6 +97,8 @@ func TestAccMackerelHostMonitor_Update(t *testing.T) {
 						"mackerel_host_monitor.foobar", "critical", "95.5"),
 					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "notification_interval", "10"),
+					resource.TestCheckResourceAttr(
+						"mackerel_host_monitor.foobar", "max_check_attempts", "3"),
 					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "scopes.#", "0"),
 					resource.TestCheckResourceAttr(
@@ -128,6 +134,8 @@ func TestAccMackerelHostMonitor_Minimum(t *testing.T) {
 						"mackerel_host_monitor.foobar", "critical", "90"),
 					resource.TestCheckResourceAttr(
 						"mackerel_host_monitor.foobar", "notification_interval", "10"),
+					resource.TestCheckResourceAttr(
+						"mackerel_host_monitor.foobar", "max_check_attempts", "3"),
 				),
 			},
 		},
@@ -166,6 +174,7 @@ resource "mackerel_host_monitor" "foobar" {
     warning               = 80.0
     critical              = 90.0
     notification_interval = 10
+    max_check_attempts    = 3
 }`, rName)
 }
 
@@ -179,6 +188,7 @@ resource "mackerel_host_monitor" "foobar" {
     warning               = 85.5
     critical              = 95.5
     notification_interval = 10
+    max_check_attempts    = 3
 }`, rName)
 }
 
@@ -192,5 +202,6 @@ resource "mackerel_host_monitor" "foobar" {
     warning               = 80.0
     critical              = 90.0
     notification_interval = 10
+    max_check_attempts    = 3
 }`, rName)
 }

--- a/internal/provider/resource_mackerel_service_monitor.go
+++ b/internal/provider/resource_mackerel_service_monitor.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/mackerelio/mackerel-client-go"
 )
 
@@ -50,6 +51,12 @@ func resourceMackerelServiceMonitor() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"max_check_attempts": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Default:      1,
+			},
 			"is_mute": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -71,6 +78,7 @@ func resourceMackerelServiceMonitorCreate(d *schema.ResourceData, meta interface
 		Warning:              pfloat64(d.Get("warning").(float64)),
 		Critical:             pfloat64(d.Get("critical").(float64)),
 		NotificationInterval: uint64(d.Get("notification_interval").(int)),
+		MaxCheckAttempts:     uint64(d.Get("max_check_attempts").(int)),
 		IsMute:               d.Get("is_mute").(bool),
 	}
 
@@ -106,6 +114,7 @@ func resourceMackerelServiceMonitorRead(d *schema.ResourceData, meta interface{}
 			_ = d.Set("warning", mon.Warning)
 			_ = d.Set("critical", mon.Critical)
 			_ = d.Set("notification_interval", mon.NotificationInterval)
+			_ = d.Set("max_check_attempts", mon.MaxCheckAttempts)
 			_ = d.Set("is_mute", mon.IsMute)
 			break
 		}
@@ -127,6 +136,7 @@ func resourceMackerelServiceMonitorUpdate(d *schema.ResourceData, meta interface
 		Warning:              pfloat64(d.Get("warning").(float64)),
 		Critical:             pfloat64(d.Get("critical").(float64)),
 		NotificationInterval: uint64(d.Get("notification_interval").(int)),
+		MaxCheckAttempts:     uint64(d.Get("max_check_attempts").(int)),
 		IsMute:               d.Get("is_mute").(bool),
 	}
 

--- a/internal/provider/resource_mackerel_service_monitor_test.go
+++ b/internal/provider/resource_mackerel_service_monitor_test.go
@@ -37,6 +37,8 @@ func TestAccMackerelServiceMonitor_Basic(t *testing.T) {
 						"mackerel_service_monitor.foobar", "critical", "90"),
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "notification_interval", "10"),
+					resource.TestCheckResourceAttr(
+						"mackerel_service_monitor.foobar", "max_check_attempts", "3"),
 				),
 			},
 		},
@@ -70,6 +72,8 @@ func TestAccMackerelServiceMonitor_Update(t *testing.T) {
 						"mackerel_service_monitor.foobar", "critical", "90"),
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "notification_interval", "10"),
+					resource.TestCheckResourceAttr(
+						"mackerel_service_monitor.foobar", "max_check_attempts", "3"),
 				),
 			},
 			{
@@ -91,6 +95,8 @@ func TestAccMackerelServiceMonitor_Update(t *testing.T) {
 						"mackerel_service_monitor.foobar", "critical", "95.5"),
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "notification_interval", "10"),
+					resource.TestCheckResourceAttr(
+						"mackerel_service_monitor.foobar", "max_check_attempts", "3"),
 				),
 			},
 		},
@@ -167,6 +173,7 @@ resource "mackerel_service_monitor" "foobar" {
   warning               = 80.0
   critical              = 90.0
   notification_interval = 10
+  max_check_attempts    = 3
 }
 `, rName, rName)
 }
@@ -186,6 +193,7 @@ resource "mackerel_service_monitor" "foobar" {
   warning               = 85.5
   critical              = 95.5
   notification_interval = 10
+  max_check_attempts    = 3
 }
 `, rName, rName)
 }
@@ -205,6 +213,7 @@ resource "mackerel_service_monitor" "foobar" {
   warning               = 80.0
   critical              = 90.0
   notification_interval = 10
+  max_check_attempts    = 3
 }
 `, rName, rName)
 }


### PR DESCRIPTION
- added max_check_attempts to host and service monitor 
- fixed max_check_attempts type of external monitor

Output acceptance test (local) :

```
gofmt -w $(find . -name '*.go' | grep -v vendor)
go vet -all .
TF_ACC=1 go test $(go list ./... | grep -v '/vendor/') -v  -timeout 120m
?       github.com/kjmkznr/terraform-provider-mackerel  [no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccMackerelDashboard_Basic
--- PASS: TestAccMackerelDashboard_Basic (0.51s)
=== RUN   TestAccMackerelDashboard_Update
--- PASS: TestAccMackerelDashboard_Update (0.58s)
=== RUN   TestAccMackerelExpressionMonitor_Basic
--- PASS: TestAccMackerelExpressionMonitor_Basic (0.57s)
=== RUN   TestAccMackerelExpressionMonitor_Update
--- PASS: TestAccMackerelExpressionMonitor_Update (0.95s)
=== RUN   TestAccMackerelExpressionMonitor_Minimum
--- PASS: TestAccMackerelExpressionMonitor_Minimum (0.44s)
=== RUN   TestAccMackerelExternalMonitor_Basic
--- PASS: TestAccMackerelExternalMonitor_Basic (0.87s)
=== RUN   TestAccMackerelExternalMonitor_Update
--- PASS: TestAccMackerelExternalMonitor_Update (1.43s)
=== RUN   TestAccMackerelExternalMonitor_Minimum
--- PASS: TestAccMackerelExternalMonitor_Minimum (0.57s)
=== RUN   TestAccMackerelHostMonitor_Basic
--- PASS: TestAccMackerelHostMonitor_Basic (0.63s)
=== RUN   TestAccMackerelHostMonitor_Update
--- PASS: TestAccMackerelHostMonitor_Update (0.91s)
=== RUN   TestAccMackerelHostMonitor_Minimum
--- PASS: TestAccMackerelHostMonitor_Minimum (0.55s)
=== RUN   TestAccMackerelServiceMonitor_Basic
--- PASS: TestAccMackerelServiceMonitor_Basic (0.89s)
=== RUN   TestAccMackerelServiceMonitor_Update
--- PASS: TestAccMackerelServiceMonitor_Update (1.28s)
=== RUN   TestAccMackerelServiceMonitor_Minimum
--- PASS: TestAccMackerelServiceMonitor_Minimum (0.88s)
=== RUN   TestAccMackerelService_Basic
--- PASS: TestAccMackerelService_Basic (0.41s)
=== RUN   Test_validateMethodWord
=== RUN   Test_validateMethodWord/Method_GET
=== RUN   Test_validateMethodWord/Method_POST
=== RUN   Test_validateMethodWord/Method_DELETE
=== RUN   Test_validateMethodWord/Method_PUT
=== RUN   Test_validateMethodWord/Method_HEAD
--- PASS: Test_validateMethodWord (0.00s)
    --- PASS: Test_validateMethodWord/Method_GET (0.00s)
    --- PASS: Test_validateMethodWord/Method_POST (0.00s)
    --- PASS: Test_validateMethodWord/Method_DELETE (0.00s)
    --- PASS: Test_validateMethodWord/Method_PUT (0.00s)
    --- PASS: Test_validateMethodWord/Method_HEAD (0.00s)
PASS
ok      github.com/kjmkznr/terraform-provider-mackerel/internal/provider        11.494s
```