### PR TITLE
Add missingDurtionWarning, missingDurationCritical in mackerel_service_monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,16 @@ Configure a service monitor.
 
 ```
 resource "mackerel_service_monitor" "foobar" {
-    name                  = "terraform_for_mackerel_test_foobar_upd"
-    service               = "Blog"
-    duration              = 10
-    metric                = "cpu%"
-    operator              = ">"
-    warning               = 85.5
-    critical              = 95.5
-    notification_interval = 10
+    name                      = "terraform_for_mackerel_test_foobar_upd"
+    service                   = "Blog"
+    duration                  = 10
+    metric                    = "cpu%"
+    operator                  = ">"
+    warning                   = 85.5
+    critical                  = 95.5
+    missing_duration_warning  = 10
+    missing_duration_critical = 100
+    notification_interval     = 10
 }
 ```
 

--- a/internal/provider/resource_mackerel_service_monitor.go
+++ b/internal/provider/resource_mackerel_service_monitor.go
@@ -47,6 +47,14 @@ func resourceMackerelServiceMonitor() *schema.Resource {
 				Type:     schema.TypeFloat,
 				Required: true,
 			},
+			"missing_duration_warning": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"missing_duration_critical": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"notification_interval": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -69,17 +77,19 @@ func resourceMackerelServiceMonitorCreate(d *schema.ResourceData, meta interface
 	client := meta.(*mackerel.Client)
 
 	input := &mackerel.MonitorServiceMetric{
-		Type:                 "service",
-		Name:                 d.Get("name").(string),
-		Service:              d.Get("service").(string),
-		Duration:             uint64(d.Get("duration").(int)),
-		Metric:               d.Get("metric").(string),
-		Operator:             d.Get("operator").(string),
-		Warning:              pfloat64(d.Get("warning").(float64)),
-		Critical:             pfloat64(d.Get("critical").(float64)),
-		NotificationInterval: uint64(d.Get("notification_interval").(int)),
-		MaxCheckAttempts:     uint64(d.Get("max_check_attempts").(int)),
-		IsMute:               d.Get("is_mute").(bool),
+		Type:                    "service",
+		Name:                    d.Get("name").(string),
+		Service:                 d.Get("service").(string),
+		Duration:                uint64(d.Get("duration").(int)),
+		Metric:                  d.Get("metric").(string),
+		Operator:                d.Get("operator").(string),
+		Warning:                 pfloat64(d.Get("warning").(float64)),
+		Critical:                pfloat64(d.Get("critical").(float64)),
+		MissingDurationWarning:  uint64(d.Get("missing_duration_warning").(int)),
+		MissingDurationCritical: uint64(d.Get("missing_duration_critical").(int)),
+		NotificationInterval:    uint64(d.Get("notification_interval").(int)),
+		MaxCheckAttempts:        uint64(d.Get("max_check_attempts").(int)),
+		IsMute:                  d.Get("is_mute").(bool),
 	}
 
 	monitor, err := client.CreateMonitor(input)
@@ -113,6 +123,8 @@ func resourceMackerelServiceMonitorRead(d *schema.ResourceData, meta interface{}
 			_ = d.Set("operator", mon.Operator)
 			_ = d.Set("warning", mon.Warning)
 			_ = d.Set("critical", mon.Critical)
+			_ = d.Set("missing_duration_warning", mon.MissingDurationWarning)
+			_ = d.Set("missing_duration_critical", mon.MissingDurationCritical)
 			_ = d.Set("notification_interval", mon.NotificationInterval)
 			_ = d.Set("max_check_attempts", mon.MaxCheckAttempts)
 			_ = d.Set("is_mute", mon.IsMute)
@@ -127,17 +139,19 @@ func resourceMackerelServiceMonitorUpdate(d *schema.ResourceData, meta interface
 	client := meta.(*mackerel.Client)
 
 	input := &mackerel.MonitorServiceMetric{
-		Type:                 "service",
-		Name:                 d.Get("name").(string),
-		Service:              d.Get("service").(string),
-		Duration:             uint64(d.Get("duration").(int)),
-		Metric:               d.Get("metric").(string),
-		Operator:             d.Get("operator").(string),
-		Warning:              pfloat64(d.Get("warning").(float64)),
-		Critical:             pfloat64(d.Get("critical").(float64)),
-		NotificationInterval: uint64(d.Get("notification_interval").(int)),
-		MaxCheckAttempts:     uint64(d.Get("max_check_attempts").(int)),
-		IsMute:               d.Get("is_mute").(bool),
+		Type:                    "service",
+		Name:                    d.Get("name").(string),
+		Service:                 d.Get("service").(string),
+		Duration:                uint64(d.Get("duration").(int)),
+		Metric:                  d.Get("metric").(string),
+		Operator:                d.Get("operator").(string),
+		Warning:                 pfloat64(d.Get("warning").(float64)),
+		Critical:                pfloat64(d.Get("critical").(float64)),
+		MissingDurationWarning:  uint64(d.Get("missing_duration_warning").(int)),
+		MissingDurationCritical: uint64(d.Get("missing_duration_critical").(int)),
+		NotificationInterval:    uint64(d.Get("notification_interval").(int)),
+		MaxCheckAttempts:        uint64(d.Get("max_check_attempts").(int)),
+		IsMute:                  d.Get("is_mute").(bool),
 	}
 
 	_, err := client.UpdateMonitor(d.Id(), input)

--- a/internal/provider/resource_mackerel_service_monitor_test.go
+++ b/internal/provider/resource_mackerel_service_monitor_test.go
@@ -36,6 +36,10 @@ func TestAccMackerelServiceMonitor_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "critical", "90"),
 					resource.TestCheckResourceAttr(
+						"mackerel_service_monitor.foobar", "missing_duration_warning", "10"),
+					resource.TestCheckResourceAttr(
+						"mackerel_service_monitor.foobar", "missing_duration_critical", "30"),
+					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "notification_interval", "10"),
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "max_check_attempts", "3"),
@@ -71,6 +75,10 @@ func TestAccMackerelServiceMonitor_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "critical", "90"),
 					resource.TestCheckResourceAttr(
+						"mackerel_service_monitor.foobar", "missing_duration_warning", "10"),
+					resource.TestCheckResourceAttr(
+						"mackerel_service_monitor.foobar", "missing_duration_critical", "30"),
+					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "notification_interval", "10"),
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "max_check_attempts", "3"),
@@ -93,6 +101,10 @@ func TestAccMackerelServiceMonitor_Update(t *testing.T) {
 						"mackerel_service_monitor.foobar", "warning", "85.5"),
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "critical", "95.5"),
+					resource.TestCheckResourceAttr(
+						"mackerel_service_monitor.foobar", "missing_duration_warning", "10"),
+					resource.TestCheckResourceAttr(
+						"mackerel_service_monitor.foobar", "missing_duration_critical", "100"),
 					resource.TestCheckResourceAttr(
 						"mackerel_service_monitor.foobar", "notification_interval", "10"),
 					resource.TestCheckResourceAttr(
@@ -172,6 +184,8 @@ resource "mackerel_service_monitor" "foobar" {
   operator              = ">"
   warning               = 80.0
   critical              = 90.0
+  missing_duration_warning = 10
+  missing_duration_critical = 30
   notification_interval = 10
   max_check_attempts    = 3
 }
@@ -192,6 +206,8 @@ resource "mackerel_service_monitor" "foobar" {
   operator              = ">"
   warning               = 85.5
   critical              = 95.5
+  missing_duration_warning = 10
+  missing_duration_critical = 100
   notification_interval = 10
   max_check_attempts    = 3
 }


### PR DESCRIPTION
Hi, @kjmkznr
In mackerel, they have added some parameters in the [Monitors API](https://mackerel.io/ja/api-docs/entry/monitors#create-service-metric-monitoring).
So, I added parameters in `resource.mackerel_service_monitor`.

