### PR TITLE
Add mackerel_channel resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,26 @@ resource "mackerel_service" "foobar" {
 }
 ```
 
+### `mackerel_channel`
+
+Configure a channel.
+
+#### Example
+
+```
+resource "mackerel_channel" "foobar" {
+  name    = "test_slack"
+  type    = "slack"
+  events  = ["alert"]
+  url = "https://hooks.slack.com/services/"
+  mentions = {
+    "ok": "status_ok",
+    "critical": "critical_alert",
+  }
+  enabled_graph_image = true
+}
+```
+
 
 Build
 -----

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -27,6 +27,7 @@ func Provider() terraform.ResourceProvider {
 			"mackerel_expression_monitor": resourceMackerelExpressionMonitor(),
 			"mackerel_dashboard":          resourceMackerelDashboard(),
 			"mackerel_service":            resourceMackerelService(),
+			"mackerel_channel":            resourceMackerelChannel(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/internal/provider/resource_mackerel_channel.go
+++ b/internal/provider/resource_mackerel_channel.go
@@ -1,0 +1,255 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+func resourceMackerelChannel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceMackerelChannelCreate,
+		Read:   resourceMackerelChannelRead,
+		Update: resourceMackerelChannelUpdate,
+		Delete: resourceMackerelChannelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"emails": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			// Field name may only contain lowercase alphanumeric characters & underscores.
+			"user_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"events": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"mentions": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enabled_graph_image": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceMackerelChannelCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*mackerel.Client)
+
+	input, err := buildChannelParameter(d)
+	if err != nil {
+		return err
+	}
+
+	channel, err := client.CreateChannel(input)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] mackerel channel %q created.", channel.ID)
+	d.SetId(channel.ID)
+
+	return resourceMackerelChannelRead(d, meta)
+}
+
+func resourceMackerelChannelRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*mackerel.Client)
+
+	log.Printf("[DEBUG] Reading mackerel channel: %q", d.Id())
+	channels, err := client.FindChannels()
+	if err != nil {
+		return err
+	}
+
+	for _, channel := range channels {
+		if channel.ID == d.Id() {
+			_ = d.Set("id", channel.ID)
+			_ = d.Set("name", channel.Name)
+			_ = d.Set("type", channel.Type)
+			_ = d.Set("url", channel.URL)
+			_ = d.Set("enabledGraphImage", channel.EnabledGraphImage)
+			_ = d.Set("user_ids", channel.UserIDs)
+			_ = d.Set("mentions", channel.Mentions)
+			_ = d.Set("events", channel.Events)
+			break
+		}
+	}
+
+	return nil
+}
+
+// DeleteChannel() -> CreateChannel()
+// Bacause, Mackerel API does not have UpdateChannel()
+func resourceMackerelChannelUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*mackerel.Client)
+
+	_, err := client.DeleteChannel(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input, err := buildChannelParameter(d)
+	if err != nil {
+		return err
+	}
+
+	channel, err := client.CreateChannel(input)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] mackerel channel %q updated.", channel.ID)
+	d.SetId(channel.ID)
+
+	return resourceMackerelChannelRead(d, meta)
+}
+
+func resourceMackerelChannelDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*mackerel.Client)
+
+	_, err := client.DeleteChannel(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] mackerel channel %q deleted.", d.Id())
+	d.SetId("")
+
+	return nil
+}
+
+func buildChannelParameter(d *schema.ResourceData) (*mackerel.Channel, error) {
+	var input *mackerel.Channel
+	var err error
+	switch channelType := d.Get("type").(string); channelType {
+	case "email":
+		input, err = buildEmailParameter(d)
+	case "slack":
+		input, err = buildSlackParameter(d)
+	case "webhook":
+		input, err = buildWebhookParameter(d)
+	}
+	return input, err
+}
+
+// build parameter for email
+func buildEmailParameter(d *schema.ResourceData) (*mackerel.Channel, error) {
+	input := &mackerel.Channel{
+		Name: d.Get("name").(string),
+		Type: d.Get("type").(string),
+	}
+
+	if v, ok := d.GetOk("emails"); ok {
+		tmp := expandStringList(v.([]interface{}))
+		input.Emails = &tmp
+	}
+
+	if v, ok := d.GetOk("user_ids"); ok {
+		tmp := expandStringList(v.([]interface{}))
+		input.UserIDs = &tmp
+	}
+
+	if input.Emails == nil && input.UserIDs == nil {
+		return nil, fmt.Errorf("emails or user_ids is required")
+	}
+
+	if v, ok := d.GetOk("events"); ok {
+		tmp := expandStringList(v.([]interface{}))
+		err := validateChannelEvent(tmp, []string{"alert", "alertGroup"})
+		if err != nil {
+			return nil, err
+		}
+		input.Events = &tmp
+	}
+
+	return input, nil
+}
+
+// build parameter for slack
+func buildSlackParameter(d *schema.ResourceData) (*mackerel.Channel, error) {
+	input := &mackerel.Channel{
+		Name: d.Get("name").(string),
+		Type: d.Get("type").(string),
+		URL:  d.Get("url").(string),
+	}
+
+	if v, ok := d.Get("enabled_graph_image").(bool); ok {
+		input.EnabledGraphImage = &v
+	}
+
+	if v, ok := d.GetOk("mentions"); ok {
+		mentionJSON, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		var mentions mackerel.Mentions
+		err = json.Unmarshal(mentionJSON, &mentions)
+		if err != nil {
+			return nil, err
+		}
+		input.Mentions = mentions
+	}
+
+	if v, ok := d.GetOk("events"); ok {
+		tmp := expandStringList(v.([]interface{}))
+		err := validateChannelEvent(tmp, []string{"alert", "alertGroup", "hostStatus", "hostRegister", "hostRetire", "monitor"})
+		if err != nil {
+			return nil, err
+		}
+		input.Events = &tmp
+	}
+
+	return input, nil
+}
+
+// build parameter for webhook
+func buildWebhookParameter(d *schema.ResourceData) (*mackerel.Channel, error) {
+	input := &mackerel.Channel{
+		Name: d.Get("name").(string),
+		Type: d.Get("type").(string),
+		URL:  d.Get("url").(string),
+	}
+
+	if v, ok := d.Get("enabled_graph_image").(bool); ok {
+		input.EnabledGraphImage = &v
+	}
+
+	if v, ok := d.GetOk("events"); ok {
+		tmp := expandStringList(v.([]interface{}))
+		err := validateChannelEvent(tmp, []string{"alert", "alertGroup", "hostStatus", "hostRegister", "hostRetire", "monitor"})
+		if err != nil {
+			return nil, err
+		}
+		input.Events = &tmp
+	}
+
+	return input, nil
+}

--- a/internal/provider/resource_mackerel_channel.go
+++ b/internal/provider/resource_mackerel_channel.go
@@ -147,17 +147,16 @@ func resourceMackerelChannelDelete(d *schema.ResourceData, meta interface{}) err
 }
 
 func buildChannelParameter(d *schema.ResourceData) (*mackerel.Channel, error) {
-	var input *mackerel.Channel
-	var err error
-	switch channelType := d.Get("type").(string); channelType {
+	switch d.Get("type").(string) {
 	case "email":
-		input, err = buildEmailParameter(d)
+		return buildEmailParameter(d)
 	case "slack":
-		input, err = buildSlackParameter(d)
+		return buildSlackParameter(d)
 	case "webhook":
-		input, err = buildWebhookParameter(d)
+		return buildWebhookParameter(d)
+	default:
+		return nil, fmt.Errorf("%v is not valid input for type", d.Get("type"))
 	}
-	return input, err
 }
 
 // build parameter for email
@@ -206,6 +205,7 @@ func buildSlackParameter(d *schema.ResourceData) (*mackerel.Channel, error) {
 	}
 
 	if v, ok := d.GetOk("mentions"); ok {
+		// Convert from schema.TypeMap to mackerel.Mentions
 		mentionJSON, err := json.Marshal(v)
 		if err != nil {
 			return nil, err

--- a/internal/provider/resource_mackerel_channel.go
+++ b/internal/provider/resource_mackerel_channel.go
@@ -47,6 +47,7 @@ func resourceMackerelChannel() *schema.Resource {
 			"url": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ConflictsWith: []string{"emails", "user_ids"},
 			},
 			"mentions": {
 				Type:     schema.TypeMap,

--- a/internal/provider/resource_mackerel_channel.go
+++ b/internal/provider/resource_mackerel_channel.go
@@ -95,7 +95,7 @@ func resourceMackerelChannelRead(d *schema.ResourceData, meta interface{}) error
 			_ = d.Set("name", channel.Name)
 			_ = d.Set("type", channel.Type)
 			_ = d.Set("url", channel.URL)
-			_ = d.Set("enabledGraphImage", channel.EnabledGraphImage)
+			_ = d.Set("enabled_graph_image", channel.EnabledGraphImage)
 			_ = d.Set("user_ids", channel.UserIDs)
 			_ = d.Set("mentions", channel.Mentions)
 			_ = d.Set("events", channel.Events)

--- a/internal/provider/resource_mackerel_channel.go
+++ b/internal/provider/resource_mackerel_channel.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/mackerelio/mackerel-client-go"
 )
 

--- a/internal/provider/resource_mackerel_channel.go
+++ b/internal/provider/resource_mackerel_channel.go
@@ -23,6 +23,11 @@ func resourceMackerelChannel() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"email",
+					"slack",
+					"webhook",
+				}, false),
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_mackerel_channel_test.go
+++ b/internal/provider/resource_mackerel_channel_test.go
@@ -46,7 +46,7 @@ func TestAccMackerelChannelEmail_Invalid(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccMackerelChannelEmailConfigInvalid(rName),
-				ExpectError: regexp.MustCompile("API request failed: invalid userIds"),
+				ExpectError: regexp.MustCompile("API request failed:"),
 			},
 		},
 	})

--- a/internal/provider/resource_mackerel_channel_test.go
+++ b/internal/provider/resource_mackerel_channel_test.go
@@ -24,6 +24,7 @@ func TestAccMackerelChannelEmail_Basic(t *testing.T) {
 			{
 				Config: testAccMackerelChannelEmailConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelChannelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "email"),
 					resource.TestCheckResourceAttrSet(resourceName, "emails.0"),
@@ -63,6 +64,7 @@ func TestAccMackerelChannelSlack_Basic(t *testing.T) {
 			{
 				Config: testAccMackerelChannelSlackConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelChannelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "slack"),
 					resource.TestCheckResourceAttrSet(resourceName, "events.0"),
@@ -88,6 +90,7 @@ func TestAccMackerelChannelWebhook_Basic(t *testing.T) {
 			{
 				Config: testAccMackerelChannelWebhookConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMackerelChannelExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "webhook"),
 					resource.TestCheckResourceAttrSet(resourceName, "events.0"),

--- a/internal/provider/resource_mackerel_channel_test.go
+++ b/internal/provider/resource_mackerel_channel_test.go
@@ -1,0 +1,198 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+func TestAccMackerelChannelEmail_Basic(t *testing.T) {
+	resourceName := "mackerel_channel.email"
+	rName := acctest.RandomWithPrefix("TerraformTestChannelEmail-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMackerelChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMackerelChannelEmailConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "email"),
+					resource.TestCheckResourceAttrSet(resourceName, "emails.0"),
+					resource.TestCheckResourceAttrSet(resourceName, "events.0"),
+					resource.TestCheckResourceAttrSet(resourceName, "user_ids.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMackerelChannelEmail_Invalid(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestChannelEmail-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMackerelChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccMackerelChannelEmailConfigInvalid(rName),
+				ExpectError: regexp.MustCompile("API request failed: invalid userIds"),
+			},
+		},
+	})
+}
+
+func TestAccMackerelChannelSlack_Basic(t *testing.T) {
+	resourceName := "mackerel_channel.slack"
+	rName := acctest.RandomWithPrefix("TerraformTestChannelSlack-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMackerelChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMackerelChannelSlackConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "slack"),
+					resource.TestCheckResourceAttrSet(resourceName, "events.0"),
+					resource.TestCheckResourceAttr(resourceName, "mentions.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mentions.ok", "ok"),
+					resource.TestCheckResourceAttr(resourceName, "mentions.critical", "critical"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_graph_image", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMackerelChannelWebhook_Basic(t *testing.T) {
+	resourceName := "mackerel_channel.webhook"
+	rName := acctest.RandomWithPrefix("TerraformTestChannelWebhook-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMackerelChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMackerelChannelWebhookConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "webhook"),
+					resource.TestCheckResourceAttrSet(resourceName, "events.0"),
+					resource.TestCheckResourceAttrSet(resourceName, "events.1"),
+					resource.TestCheckResourceAttr(resourceName, "url", "https://hogehoge.com"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_graph_image", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMackerelChannelDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*mackerel.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mackerel_channel" {
+			continue
+		}
+
+		channels, err := client.FindChannels()
+		if err != nil {
+			return fmt.Errorf("find channel failed")
+		}
+		for _, chn := range channels {
+			if rs.Primary.ID == chn.ID {
+				return fmt.Errorf("channel still exists")
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMackerelChannelExists(resouceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*mackerel.Client)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "mackerel_channel" {
+				continue
+			}
+
+			channels, err := client.FindChannels()
+			if err != nil {
+				return fmt.Errorf("find channel failed")
+			}
+			for _, chn := range channels {
+				if rs.Primary.ID == chn.ID {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("channel (%s) not found", resouceName)
+	}
+}
+
+func testAccMackerelChannelEmailConfigBasic(rName string) string {
+	return fmt.Sprintf(`
+resource "mackerel_channel" "email" {
+  name    = "%s"
+  type    = "email"
+  emails  = ["foo@exapmle.com","bar@exapmle.com"]
+  events  = ["alert"]
+  user_ids = ["%s"]
+}
+`, rName, os.Getenv("USER_ID"))
+}
+
+func testAccMackerelChannelEmailConfigInvalid(rName string) string {
+	return fmt.Sprintf(`
+resource "mackerel_channel" "email" {
+  name    = "%s"
+  type    = "email"
+  emails  = ["foo@exapmle.com","bar@exapmle.com"]
+  events  = ["alert"]
+  user_ids = ["hoge"]
+}
+`, rName)
+}
+
+func testAccMackerelChannelSlackConfigBasic(rName string) string {
+	return fmt.Sprintf(`
+resource "mackerel_channel" "slack" {
+  name    = "%s"
+  type    = "slack"
+  events  = ["alert"]
+  url = "https://hooks.slack.com/services/"
+  mentions = {
+    "ok": "ok",
+    "critical": "critical",
+  }
+  enabled_graph_image = true
+}
+`, rName)
+}
+
+func testAccMackerelChannelWebhookConfigBasic(rName string) string {
+	return fmt.Sprintf(`
+resource "mackerel_channel" "webhook" {
+  name    = "%s"
+  type    = "webhook"
+  events  = ["alert", "monitor"]
+  url = "https://hogehoge.com"
+  enabled_graph_image = true
+}
+`, rName)
+}

--- a/internal/provider/resource_mackerel_channel_test.go
+++ b/internal/provider/resource_mackerel_channel_test.go
@@ -95,7 +95,7 @@ func TestAccMackerelChannelWebhook_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "webhook"),
 					resource.TestCheckResourceAttrSet(resourceName, "events.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "events.1"),
-					resource.TestCheckResourceAttr(resourceName, "url", "https://hogehoge.com"),
+					resource.TestCheckResourceAttr(resourceName, "url", "https://example.com"),
 					resource.TestCheckResourceAttr(resourceName, "enabled_graph_image", "true"),
 				),
 			},
@@ -157,7 +157,7 @@ resource "mackerel_channel" "email" {
   events  = ["alert"]
   user_ids = ["%s"]
 }
-`, rName, os.Getenv("USER_ID"))
+`, rName, os.Getenv("MACKEREL_USER_ID"))
 }
 
 func testAccMackerelChannelEmailConfigInvalid(rName string) string {
@@ -167,7 +167,7 @@ resource "mackerel_channel" "email" {
   type    = "email"
   emails  = ["foo@exapmle.com","bar@exapmle.com"]
   events  = ["alert"]
-  user_ids = ["hoge"]
+  user_ids = ["invalid_user_id"]
 }
 `, rName)
 }
@@ -194,7 +194,7 @@ resource "mackerel_channel" "webhook" {
   name    = "%s"
   type    = "webhook"
   events  = ["alert", "monitor"]
-  url = "https://hogehoge.com"
+  url = "https://example.com"
   enabled_graph_image = true
 }
 `, rName)

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -29,3 +29,21 @@ func validateMethodWord(v interface{}, k string) (warns []string, errors []error
 	}
 	return
 }
+
+func validateChannelEvent(events []string, validEvents []string) error {
+	for _, e := range events {
+		if !isStringInSlice(e, validEvents) {
+			return fmt.Errorf("%s is not valid event", e)
+		}
+	}
+	return nil
+}
+
+func isStringInSlice(target string, strings []string) bool {
+	for _, s := range strings {
+		if target == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Hi, @kjmkznr 
I added `mackerel channel resource`, based on #20.

Please, check this pull request.

## Question.
I wanna discuss about the [test](https://github.com/kjmkznr/terraform-provider-mackerel/pull/39/files#diff-8103f1e91c636ab7d693cdb460e6546b7a9570cbe027d2c0099747455801fc5cR157) for channel email.
Mackerel API requires a valid user_id to create some of resources, and I do not know how you do acceptance test. So, for this pull, I implemented the test with environment variable `USER_ID`.
But, I wonder if its good or not and I propose two ways to handle it.
1. Set the environment variable, `USER_ID`, and `make testacc`.
2. Just delete `testAccMackerelChannelEmailConfigBasic`, which means do not tests that require valid user_id.
